### PR TITLE
Added flags for building local static libraries

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@
 PREFIX=/usr/local
 CC=gcc
 CFLAGS=-c -fPIC -Wall -D_REENTRANT $(ADDITIONALFLAGS)
-LIBS=-lc -lorcania
+LIBS=-lc -lorcania $(ADDITIONALLIBS)
 OUTPUT=libyder.so
 VERSION=1.2.0
 


### PR DESCRIPTION
I'm building ulfius in a situation where I need to install the libraries and headers as part of my working directory, so I made a small change to the Makefile to support that.