### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,17 @@ jobs:
     - env: LABEL=cppcheck
       script:
         - cppcheck --force --enable=warning,missingInclude --error-exitcode=1 .
+  # ppc64le support code 
+    - env: LABEL=linux-gcc
+      arch: ppc64le
+      compiler: gcc
+    - env: LABEL=linux-clang
+      arch: ppc64le
+      compiler: clang
+    - env: LABEL=cppcheck
+      arch: ppc64le   
+      script:
+        - cppcheck --force --enable=warning,missingInclude --error-exitcode=1 .    
 script:
   - mkdir build && cd build
   - cmake -DBUILD_YDER_TESTING=on ..


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
The build and test results are available at the below location.
https://travis-ci.org/github/nageshlop/yder/builds/746073772