### PR TITLE
Use gmtime_s on Windows

### DIFF
--- a/src/yder.c
+++ b/src/yder.c
@@ -45,8 +45,13 @@ static void y_write_log_console(const char * app_name, const char * date_format,
   char * level_name = NULL, date_stamp[64];
   FILE * output = NULL;
   struct tm tm_stamp;
+
+#ifdef _WIN32
+  gmtime_s(&tm_stamp, &date);
+#else
   gmtime_r(&date, &tm_stamp);
-  
+#endif
+
   if (date_format == NULL) {
 #ifndef _WIN32
     strftime (date_stamp, sizeof(date_stamp), "%FT%TZ", &tm_stamp);
@@ -138,7 +143,11 @@ static void y_write_log_file(const char * app_name, const char * date_format, co
   struct tm tm_stamp;
   
   if (log_file != NULL) {
+#ifdef _WIN32
+    gmtime_s(&tm_stamp, &date);
+#else
     gmtime_r(&date, &tm_stamp);
+#endif
     if (date_format == NULL) {
 #ifndef _WIN32
       strftime (date_stamp, sizeof(date_stamp), "%FT%TZ", &tm_stamp);


### PR DESCRIPTION
This pull request uses `gmtime_s` when `_WIN32` is defined instead of `gmtime_r` as the latter is not available in Win32. These functions do the exact same thing, its just that it has a different name in the Windows API. Tested to compile and work with x86_64-mingw64 on MSYS2.